### PR TITLE
Support for rotation, fix some visual glitches, and add build previews.

### DIFF
--- a/DSP_CopyInserters/CopyInserters.cs
+++ b/DSP_CopyInserters/CopyInserters.cs
@@ -18,7 +18,7 @@ namespace DSP_Mods.CopyInserters
         void Update()
         {
   
-            if (Input.GetKeyUp(KeyCode.LeftControl))
+            if (Input.GetKeyUp(KeyCode.Tab))
             {
                 copyEnabled = !copyEnabled;
             }
@@ -70,7 +70,7 @@ namespace DSP_Mods.CopyInserters
             if (!tip)
             {
                 allTips = ___allTips;
-                tip = __instance.RegisterTip("L-CTRL", "Toggle inserters copy");
+                tip = __instance.RegisterTip("TAB", "Toggle inserters copy");
             }
             tip.desired = IsCopyAvailable();
         }

--- a/DSP_CopyInserters/CopyInserters.cs
+++ b/DSP_CopyInserters/CopyInserters.cs
@@ -534,8 +534,18 @@ namespace DSP_Mods.CopyInserters
                 {
                     foreach (var buildPreview in __instance.buildPreviews)
                     {
-                        var targetPos = __instance.previewPose.position + __instance.previewPose.rotation * buildPreview.lpos;
-                        var targetRot = __instance.previewPose.rotation;
+                        Vector3 targetPos;
+                        Quaternion targetRot;
+                        if (__instance.buildPreviews.Count > 1)
+                        {
+                            targetPos = buildPreview.lpos;
+                            targetRot = buildPreview.lrot;
+                        }
+                        else
+                        {
+                            targetPos = __instance.previewPose.position + __instance.previewPose.rotation * buildPreview.lpos;
+                            targetRot = __instance.previewPose.rotation;
+                        }
                         var entityPool = ___factory.entityPool;
                         foreach (var inserter in ci)
                         {

--- a/DSP_CopyInserters/CopyInserters.cs
+++ b/DSP_CopyInserters/CopyInserters.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
 using BepInEx;
 using HarmonyLib;
 using UnityEngine;
@@ -25,7 +29,14 @@ namespace DSP_Mods.CopyInserters
         internal void Awake()
         {
             harmony = new Harmony("org.fezeral.plugins.copyinserters");
-            harmony.PatchAll(typeof(PatchCopyInserters));
+            try
+            {
+                harmony.PatchAll(typeof(PatchCopyInserters));
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.ToString());
+            }
 
             PatchCopyInserters.cachedInserters = new List<PatchCopyInserters.CachedInserter>();
             PatchCopyInserters.pendingInserters = new List<PatchCopyInserters.PendingInserter>();
@@ -41,16 +52,226 @@ namespace DSP_Mods.CopyInserters
             internal static List<CachedInserter> cachedInserters; // During copy mode, cached info on inserters attached to the copied building
             internal static List<PendingInserter> pendingInserters; // Info on inserters for every unbuilt pasted building
 
+
+            /// <summary>
+            /// After any item has completed building, check if there are pendingInserters to request
+            /// </summary>
+            /// <param name="postObjId">The built entities object ID</param>
+            [HarmonyPostfix]
+            [HarmonyPatch(typeof(PlayerAction_Build), "DetermineBuildPreviews")]
+            public static void PlayerAction_BuildDetermineBuildPreviewsPostfix(PlayerAction_Build __instance)
+            {
+                // Do we have cached inserters?
+                var ci = PatchCopyInserters.cachedInserters;
+                if (ci.Count > 0)
+                {
+                    for (int i = 0; i < __instance.buildPreviews.Count; i++)
+                    {
+                        var buildingPreview = __instance.buildPreviews[i];
+                        if (!buildingPreview.item.prefabDesc.isInserter)
+                        {
+                            foreach (var inserter in ci)
+                            {
+                                var bp = BuildPreview.CreateSingle(LDB.items.Select(inserter.protoId), LDB.items.Select(inserter.protoId).prefabDesc, true);
+                                bp.ResetInfos();
+                                
+                                bp.lpos = buildingPreview.lpos + buildingPreview.lrot * inserter.posDelta;
+                                bp.lrot = buildingPreview.lrot * inserter.rot;
+                                bp.lpos2 = buildingPreview.lpos + buildingPreview.lrot * inserter.pos2Delta;
+                                bp.lrot2 = buildingPreview.lrot * inserter.rot2;
+                                bp.ignoreCollider = true;
+                                __instance.AddBuildPreview(bp);
+                            }
+                        }
+                        
+                    }
+                    
+                }
+
+            }
+
+            [HarmonyPostfix]
+            [HarmonyPatch(typeof(PlayerAction_Build), "CheckBuildConditions")]
+            public static void PlayerAction_BuildCheckBuildConditionsPostfix(PlayerAction_Build __instance, ref bool __result)
+            {
+                var ci = PatchCopyInserters.cachedInserters;
+
+                if (ci.Count > 0)
+                {
+                    __instance.cursorText = __instance.prepareCursorText;
+                    __instance.prepareCursorText = string.Empty;
+                    __instance.cursorWarning = false;
+                    UICursor.SetCursor(ECursor.Default);
+                    var flag = true;
+                    for (int i = 0; i < __instance.buildPreviews.Count; i++)
+                    {
+                        BuildPreview buildPreview = __instance.buildPreviews[i];
+                        bool isInserter = buildPreview.desc.isInserter;
+
+                        if (isInserter && buildPreview.ignoreCollider && (buildPreview.condition == EBuildCondition.TooFar || buildPreview.condition == EBuildCondition.TooClose))
+                        {
+                            buildPreview.condition = EBuildCondition.Ok;
+                        } 
+                        
+                        if(buildPreview.condition != EBuildCondition.Ok)
+                        {
+                            flag = false;
+                            if (!__instance.cursorWarning)
+                            {
+                                __instance.cursorWarning = true;
+                                __instance.cursorText = buildPreview.conditionText;
+                            }
+                        }
+                    }
+
+                    if (!flag && !VFInput.onGUI)
+                    {
+                        UICursor.SetCursor(ECursor.Ban);
+                    }
+
+                    __result = flag;
+                }
+            }
+
+            [HarmonyPrefix]
+            [HarmonyPatch(typeof(PlayerAction_Build), "CreatePrebuilds")]
+            public static void PlayerAction_BuildCreatePrebuildsPrefix(PlayerAction_Build __instance)
+            {
+                var ci = PatchCopyInserters.cachedInserters;
+
+                if (ci.Count > 0)
+                {
+                    // for now we remove the inserters prebuilds
+                    if (__instance.waitConfirm && VFInput._buildConfirm.onDown && __instance.buildPreviews.Count > 0)
+                    {
+                        for (int i = __instance.buildPreviews.Count - 1; i >= 0; i--) // Reverse loop for removing found elements
+                        {
+                            var buildPreview = __instance.buildPreviews[i];
+                            bool isInserter = buildPreview.desc.isInserter;
+
+                            if (isInserter && buildPreview.ignoreCollider)
+                            {
+                                __instance.buildPreviews.RemoveAt(i);
+                                __instance.FreePreviewModel(buildPreview);
+                            }
+
+                        }
+                    }
+                }
+            }
+
+
+            [HarmonyReversePatch]
+            [HarmonyPatch(typeof(PlayerAction_Build), "DetermineBuildPreviews")]
+            public static void CalculatePose(PlayerAction_Build __instance, int startObjId, int castObjId)
+            {
+                IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+                {
+                    List<CodeInstruction> instructionsList = instructions.ToList();
+
+                    // Find the idx at which the "cargoTraffic" field of the PlanetFactory
+                    // Is first accessed since this is the start of the instructions that compute posing
+
+                    /* ex of the code in dotpeek:
+                     * ```
+                     * if (this.cursorValid && this.startObjId != this.castObjId && (this.startObjId > 0 && this.castObjId > 0))
+                     * {
+                     *   CargoTraffic cargoTraffic = this.factory.cargoTraffic; <- WE WANT TO START WITH THIS LINE (INCLUSIVE)
+                     *   EntityData[] entityPool = this.factory.entityPool;
+                     *   BeltComponent[] beltPool = cargoTraffic.beltPool;
+                     *   this.posePairs.Clear();
+                     *   this.startSlots.Clear();
+                     * ```
+                     */
+
+                    int startIdx = -1;
+                    for (int i = 0; i < instructionsList.Count; i++)
+                    {
+                        if (instructionsList[i].LoadsField(typeof(PlanetFactory).GetField("cargoTraffic")))
+                        {
+                            startIdx = i - 2; // need the two proceeding lines that are ldarg.0 and ldfld PlayerAction_Build::factory
+                            break;
+                        }
+                    }
+                    if (startIdx == -1)
+                    {
+                        throw new InvalidOperationException("Cannot patch sorter posing code b/c the start indicator isn't present");
+                    }
+
+                    // Find the idx at which the "posePairs" field of the PlayerAction_Build
+                    // Is first accessed and followed by a call to get_Count
+
+                    /*
+                     * ex of the code in dotpeek:
+                     * ```
+                     *          else
+                     *              flag6 = true;
+                     *      }
+                     *      else
+                     *        flag6 = true;
+                     *    }
+                     *  }
+                     *  if (this.posePairs.Count > 0) <- WE WANT TO END ON THIS LINE (EXCLUSIVE)
+                     *  {
+                     *    float num1 = 1000f;
+                     *    float num2 = Vector3.Distance(this.currMouseRay.origin, this.cursorTarget) + 10f;
+                     *    PlayerAction_Build.PosePair posePair2 = new PlayerAction_Build.PosePair();
+                     * ```
+                     */
+
+                    int endIdx = -1;
+                    for (int i = startIdx; i < instructionsList.Count - 1; i++) // go to the end - 1 b/c we need to check two instructions to find valid loc
+                    {
+                        if (instructionsList[i].LoadsField(typeof(PlayerAction_Build).GetField("posePairs")))
+                        {
+                            if (instructionsList[i + 1].Calls(typeof(List<PlayerAction_Build.PosePair>).GetMethod("get_Count")))
+                            {
+                                endIdx = i - 1; // need the proceeding line that is ldarg.0
+                                break;
+                            }
+                        }
+                    }
+                    if (endIdx == -1)
+                    {
+                        throw new InvalidOperationException("Cannot patch sorter posing code b/c the end indicator isn't present");
+                    }
+
+                    // The first argument to an instance method (arg 0) is the instance itself
+                    // Since this is a static method, the instance will still need to be passed
+                    // For the IL instructions to work properly so manually pass the instance as
+                    // The first argument to the method.
+                    List<CodeInstruction> code = new List<CodeInstruction>()
+                    {
+                        new CodeInstruction(OpCodes.Ldarg_0),
+                        new CodeInstruction(OpCodes.Ldarg_1),
+                        CodeInstruction.StoreField(typeof(PlayerAction_Build), "startObjId"),
+                        new CodeInstruction(OpCodes.Ldarg_0),
+                        new CodeInstruction(OpCodes.Ldarg_2),
+                        CodeInstruction.StoreField(typeof(PlayerAction_Build), "castObjId"),
+                    };
+
+                    for (int i = startIdx; i < endIdx; i++)
+                    {
+                        code.Add(instructionsList[i]);
+                    }
+                    return code.AsEnumerable();
+                }
+
+                // make compiler happy
+                _ = Transpiler(null);
+                return;
+            }
+
             /// <summary>
             /// After any item has completed building, check if there are pendingInserters to request
             /// </summary>
             /// <param name="postObjId">The built entities object ID</param>
             [HarmonyPrefix]
             [HarmonyPatch(typeof(PlayerAction_Build), "NotifyBuilt")]
-            public static void PlayerAction_BuildNotifyBuiltPrefix(int postObjId, PlanetAuxData ___planetAux)
+            public static void PlayerAction_BuildNotifyBuiltPrefix(PlayerAction_Build __instance, int postObjId, PlanetAuxData ___planetAux)
             {
                 var entityBuilt = pc.player.factory.entityPool[postObjId];
-                                
+
                 ModelProto modelProto = LDB.models.Select(entityBuilt.modelIndex);
                 var prefabDesc = modelProto.prefabDesc;
                 if (!prefabDesc.isInserter)
@@ -59,7 +280,7 @@ namespace DSP_Mods.CopyInserters
                     if (PatchCopyInserters.pendingInserters.Count > 0)
                     {
                         var factory = pc.player.factory;
-                        for(int i = pendingInserters.Count -1; i >= 0; i--) // Reverse loop for removing found elements
+                        for (int i = pendingInserters.Count - 1; i >= 0; i--) // Reverse loop for removing found elements
                         {
                             var pi = pendingInserters[i];
                             // Is the NotifyBuilt assembler in the expected position for this pending inserter?
@@ -67,34 +288,67 @@ namespace DSP_Mods.CopyInserters
                             if (distance < 0.2)
                             {
                                 var assemblerId = entityBuilt.id;
-                                //Debug.Log($"!!! found assembler id={assemblerId} at Pos={entityBuilt.pos} expected {pi.AssemblerPos} distance={distance}");
-                                
+
                                 // Create inserter Prebuild data
                                 var pbdata = new PrebuildData();
                                 pbdata.protoId = (short)pi.ci.protoId;
                                 pbdata.modelIndex = (short)LDB.items.Select(pi.ci.protoId).ModelIndex;
-                                //pbdata.modelId = factory.entityPool[pi.otherId].modelId;
-                                pbdata.rot = pi.ci.rot;
-                                pbdata.rot2 = pi.ci.rot2;
 
-                                // Copy rot from building, smelters have problems here
-                                pbdata.rot = entityBuilt.rot;
-                                pbdata.rot2 = entityBuilt.rot;
-                                
                                 pbdata.insertOffset = pi.ci.insertOffset;
                                 pbdata.pickOffset = pi.ci.pickOffset;
                                 pbdata.filterId = pi.ci.filterId;
-                                
-                                // Calculate inserter start and end positions from stored delta's
-                                pbdata.pos = entityBuilt.pos + pi.ci.posDelta;
-                                pbdata.pos = ___planetAux.Snap(pbdata.pos, true, false);
-                                pbdata.pos2 = ___planetAux.Snap(pbdata.pos + pi.ci.pos2delta, true, false);
 
-                                // Reverse positions for inserters that unload the copied building
+                                // Calculate inserter start and end positions from stored deltas and the building's rotation
+                                pbdata.pos = ___planetAux.Snap(entityBuilt.pos + entityBuilt.rot * pi.ci.posDelta, true, false);
+                                pbdata.pos2 = ___planetAux.Snap(entityBuilt.pos + entityBuilt.rot * pi.ci.pos2Delta, true, false);
+                                // Get inserter rotation relative to the building's
+                                pbdata.rot = entityBuilt.rot * pi.ci.rot;
+                                pbdata.rot2 = entityBuilt.rot * pi.ci.rot2;
+
                                 if (!pi.ci.incoming)
                                 {
-                                    pbdata.pos = ___planetAux.Snap(entityBuilt.pos - pi.ci.posDelta, true, false);
-                                    pbdata.pos2 = ___planetAux.Snap(pbdata.pos + pi.ci.pos2delta, true, false);
+                                    CalculatePose(__instance, assemblerId, pi.otherId);
+                                }
+                                else
+                                {
+                                    CalculatePose(__instance, pi.otherId, assemblerId);
+                                }
+                                if (__instance.posePairs.Count > 0)
+                                {
+                                    float minDistance = 1000f;
+                                    PlayerAction_Build.PosePair bestFit = new PlayerAction_Build.PosePair();
+                                    bool hasNearbyPose = false;
+                                    // Calculate inserter start and end positions from stored deltas and the building's rotation
+                                    pbdata.pos = ___planetAux.Snap(entityBuilt.pos + entityBuilt.rot * pi.ci.posDelta, true, false);
+                                    pbdata.pos2 = ___planetAux.Snap(entityBuilt.pos + entityBuilt.rot * pi.ci.pos2Delta, true, false);
+                                    for (int j = 0; j < __instance.posePairs.Count; ++j)
+                                    {
+                                        if (__instance.posePairs[j].startSlot != pi.ci.startSlot || __instance.posePairs[j].endSlot != pi.ci.endSlot)
+                                        {
+                                            continue;
+                                        }
+                                        float startDistance = Vector3.Distance(__instance.posePairs[j].startPose.position, pbdata.pos);
+                                        float endDistance = Vector3.Distance(__instance.posePairs[j].endPose.position, pbdata.pos2);
+                                        float poseDistance = startDistance + endDistance;
+
+                                        if (poseDistance < minDistance)
+                                        {
+                                            minDistance = poseDistance;
+                                            bestFit = __instance.posePairs[j];
+                                            hasNearbyPose = true;
+                                        }
+                                    }
+                                    if (hasNearbyPose)
+                                    {
+                                        // if we were able to calculate a close enough sensible pose
+                                        // use that instead of the (visually) ugly default
+
+                                        pbdata.pos = bestFit.startPose.position;
+                                        pbdata.pos2 = bestFit.endPose.position;
+
+                                        pbdata.rot = bestFit.startPose.rotation;
+                                        pbdata.rot2 = bestFit.endPose.rotation * Quaternion.Euler(0.0f, 180f, 0.0f);
+                                    }
                                 }
 
                                 // Check the player has the item in inventory, no cheating here
@@ -108,12 +362,12 @@ namespace DSP_Mods.CopyInserters
 
                                     // Otherslot -1 will try to find one, otherwise could cache this from original assembler if it causes problems
                                     if (pi.ci.incoming)
-                                    {                                        
+                                    {
                                         factory.WriteObjectConn(-pbCursor, 0, true, assemblerId, -1); // assembler connection                                        
                                         factory.WriteObjectConn(-pbCursor, 1, false, pi.otherId, -1); // other connection
                                     }
                                     else
-                                    {                                        
+                                    {
                                         factory.WriteObjectConn(-pbCursor, 0, false, assemblerId, -1); // assembler connection                                        
                                         factory.WriteObjectConn(-pbCursor, 1, true, pi.otherId, -1); // other connection
                                     }
@@ -122,7 +376,7 @@ namespace DSP_Mods.CopyInserters
                             }
                         }
                     }
-                }                
+                }
             }
 
             /// <summary>
@@ -130,7 +384,7 @@ namespace DSP_Mods.CopyInserters
             /// </summary>
             [HarmonyPostfix]
             [HarmonyPatch(typeof(PlayerAction_Build), "SetCopyInfo")]
-            public static void PlayerAction_BuildSetCopyInfoPostfix(ref PlanetFactory ___factory, int objectId, PlanetAuxData ___planetAux)
+            public static void PlayerAction_BuildSetCopyInfoPostfix(PlayerAction_Build __instance, ref PlanetFactory ___factory, int objectId, PlanetAuxData ___planetAux)
             {
                 cachedInserters.Clear(); // Remove previous copy info
                 if (objectId < 0) // Copied item is a ghost, no inserters to cache
@@ -138,10 +392,12 @@ namespace DSP_Mods.CopyInserters
 
                 var sourceEntity = objectId;
                 var sourcePos = ___factory.entityPool[objectId].pos;
+                var sourceRot = ___factory.entityPool[objectId].rot;
                 // Find connected inserters                
                 int matches = 0;
                 var inserterPool = ___factory.factorySystem.inserterPool;
                 var entityPool = ___factory.entityPool;
+
                 for (int i = 1; i < ___factory.factorySystem.inserterCursor; i++)
                 {
                     if (inserterPool[i].id == i)
@@ -152,37 +408,73 @@ namespace DSP_Mods.CopyInserters
                         if (pickTarget == sourceEntity || insertTarget == sourceEntity)
                         {
                             matches++;
-                            var inserterType = ___factory.entityPool[inserter.entityId].protoId;
+                            var inserterEntity = entityPool[inserter.entityId];
+                            var inserterType = inserterEntity.protoId;
                             bool incoming = insertTarget == sourceEntity;
                             var otherId = incoming ? pickTarget : insertTarget; // The belt or other building this inserter is attached to
-                            var otherPos = ___factory.entityPool[otherId].pos;
+                            var otherPos = entityPool[otherId].pos;
 
                             // Store the Grid-Snapped moves from assembler to belt/other                            
-                            Vector3 begin = sourcePos;
-                            Vector3 end = otherPos;
+ 
                             int path = 0;
                             Vector3[] snaps = new Vector3[6];
-                            var snappedPointCount = ___planetAux.SnapLineNonAlloc(begin, end, ref path, snaps);
-                            Vector3 lastSnap = begin;
+                            var snappedPointCount = ___planetAux.SnapLineNonAlloc(sourcePos, otherPos, ref path, snaps);
+                            Vector3 lastSnap = sourcePos;
                             Vector3[] snapMoves = new Vector3[snappedPointCount];
                             for (int s = 0; s < snappedPointCount; s++)
                             {
-                                Vector3 snapMove = snaps[s] - lastSnap;
+                                // note: reverse rotation of the delta so that rotation works
+                                Vector3 snapMove = Quaternion.Inverse(sourceRot) * (snaps[s] - lastSnap);
                                 snapMoves[s] = snapMove;
                                 lastSnap = snaps[s];
                             }
 
                             // Cache info for this inserter
                             var ci = new CachedInserter();
-                            ci.otherDelta = (otherPos - sourcePos); // Delta from copied building to other belt/building
                             ci.incoming = incoming;
-                            ci.protoId = inserterType;
-                            ci.rot = ___factory.entityPool[inserter.entityId].rot;
-                            ci.rot2 = inserter.rot2;
-                            ci.pos2delta = (inserter.pos2 - entityPool[inserter.entityId].pos); // Delta from inserter pos2 to copied building
-                            var posDelta = entityPool[inserter.entityId].pos - sourcePos; // Delta from copied building to inserter pos
-                            if (!incoming) posDelta = sourcePos - entityPool[inserter.entityId].pos; // Reverse for outgoing inserters
-                            ci.posDelta = posDelta;
+                            ci.protoId = inserterEntity.protoId;
+
+                            // rotations + deltas relative to the source building's rotation
+                            ci.rot = Quaternion.Inverse(sourceRot) * inserterEntity.rot;
+                            ci.rot2 = Quaternion.Inverse(sourceRot) * inserter.rot2;
+                            ci.posDelta = Quaternion.Inverse(sourceRot) * (inserterEntity.pos - sourcePos); // Delta from copied building to inserter pos
+                            ci.pos2Delta = Quaternion.Inverse(sourceRot) * (inserter.pos2 - sourcePos); // Delta from copied building to inserter pos2
+
+
+                            // compute the start and end slot that the cached inserter uses
+                            if (!incoming)
+                            {
+                                CalculatePose(__instance, sourceEntity, otherId);
+                            }
+                            else
+                            {
+                                CalculatePose(__instance, otherId, sourceEntity);
+                            }
+
+                            if (__instance.posePairs.Count > 0)
+                            {
+                                float minDistance = 1000f;
+                                PlayerAction_Build.PosePair bestFit = new PlayerAction_Build.PosePair();
+                                bool hasNearbyPose = false;
+                                for (int j = 0; j < __instance.posePairs.Count; ++j)
+                                {
+                                    float startDistance = Vector3.Distance(__instance.posePairs[j].startPose.position, inserterEntity.pos);
+                                    float endDistance = Vector3.Distance(__instance.posePairs[j].endPose.position, inserter.pos2);
+                                    float poseDistance = startDistance + endDistance;
+
+                                    if (poseDistance < minDistance)
+                                    {
+                                        minDistance = poseDistance;
+                                        bestFit = __instance.posePairs[j];
+                                        hasNearbyPose = true;
+                                    }
+                                }
+                                if (hasNearbyPose)
+                                {
+                                    ci.startSlot = bestFit.startSlot;
+                                    ci.endSlot = bestFit.endSlot;
+                                }
+                            }
 
                             // not important?
                             ci.pickOffset = inserter.pickOffset;
@@ -190,7 +482,7 @@ namespace DSP_Mods.CopyInserters
                             // needed for pose?
                             ci.t1 = inserter.t1;
                             ci.t2 = inserter.t2;
-                            
+
 
                             ci.filterId = inserter.filter;
                             ci.snapMoves = snapMoves;
@@ -208,9 +500,10 @@ namespace DSP_Mods.CopyInserters
             {
                 public int protoId;
                 public bool incoming;
+                public int startSlot;
+                public int endSlot;
                 public Vector3 posDelta;
-                public Vector3 pos2delta;
-                public Vector3 otherDelta;
+                public Vector3 pos2Delta;
                 public Quaternion rot;
                 public Quaternion rot2;
                 public short pickOffset;
@@ -245,17 +538,17 @@ namespace DSP_Mods.CopyInserters
                     foreach (var buildPreview in __instance.buildPreviews)
                     {
                         var targetPos = __instance.previewPose.position + __instance.previewPose.rotation * buildPreview.lpos;
+                        var targetRot = __instance.previewPose.rotation;
                         var entityPool = ___factory.entityPool;
                         foreach (var inserter in ci)
                         {
                             // Find the desired belt/building position
                             // As delta doesn't work over distance, re-trace the Grid Snapped steps from the original
                             // to find the target belt/building for this inserters other connection
-                            var currentPos = targetPos;
+                            var testPos = targetPos;
+                            // Note: rotate's each move relative to the rotation of the new building
                             for (int u = 0; u < inserter.snapCount; u++)
-                                currentPos = ___planetAux.Snap(currentPos + inserter.snapMoves[u], true, false);
-
-                            var testPos = currentPos;
+                                testPos = ___planetAux.Snap(testPos + targetRot * inserter.snapMoves[u], true, false);
 
                             // Find the other entity at the target location
                             int otherId = 0;

--- a/DSP_CopyInserters/CopyInserters.cs
+++ b/DSP_CopyInserters/CopyInserters.cs
@@ -341,6 +341,8 @@ namespace DSP_Mods.CopyInserters
                                 pbdata.pickOffset = pi.ci.pickOffset;
                                 pbdata.filterId = pi.ci.filterId;
 
+                                pbdata.refCount = pi.ci.refCount;
+
                                 // Calculate inserter start and end positions from stored deltas and the building's rotation
                                 pbdata.pos = ___planetAux.Snap(entityBuilt.pos + entityBuilt.rot * pi.ci.posDelta, true, false);
                                 pbdata.pos2 = ___planetAux.Snap(entityBuilt.pos + entityBuilt.rot * pi.ci.pos2Delta, true, false);
@@ -478,7 +480,8 @@ namespace DSP_Mods.CopyInserters
                             ci.posDelta = Quaternion.Inverse(sourceRot) * (inserterEntity.pos - sourcePos); // Delta from copied building to inserter pos
                             ci.pos2Delta = Quaternion.Inverse(sourceRot) * (inserter.pos2 - sourcePos); // Delta from copied building to inserter pos2
 
-
+                            ItemProto itemProto = LDB.items.Select(ci.protoId);
+                            ci.refCount = Mathf.RoundToInt((float)(inserter.stt - 0.499f) / itemProto.prefabDesc.inserterSTT);
                             // compute the start and end slot that the cached inserter uses
                             if (!incoming)
                             {
@@ -550,6 +553,7 @@ namespace DSP_Mods.CopyInserters
                 public int filterId;
                 public Vector3[] snapMoves;
                 public int snapCount;
+                public int refCount;
             }
 
             //For inserters that need to be built when assembler is ready

--- a/DSP_CopyInserters/CopyInserters.cs
+++ b/DSP_CopyInserters/CopyInserters.cs
@@ -65,7 +65,8 @@ namespace DSP_Mods.CopyInserters
                 var ci = PatchCopyInserters.cachedInserters;
                 if (ci.Count > 0)
                 {
-                    for (int i = 0; i < __instance.buildPreviews.Count; i++)
+                    var bpCount = __instance.buildPreviews.Count;
+                    for (int i = 0; i < bpCount; i++)
                     {
                         var buildingPreview = __instance.buildPreviews[i];
                         if (!buildingPreview.item.prefabDesc.isInserter)

--- a/DSP_CopyInserters/CopyInserters.cs
+++ b/DSP_CopyInserters/CopyInserters.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Reflection.Emit;
 using BepInEx;
 using HarmonyLib;
@@ -109,7 +108,10 @@ namespace DSP_Mods.CopyInserters
                         BuildPreview buildPreview = __instance.buildPreviews[i];
                         bool isInserter = buildPreview.desc.isInserter;
 
-                        if (isInserter && buildPreview.ignoreCollider && (buildPreview.condition == EBuildCondition.TooFar || buildPreview.condition == EBuildCondition.TooClose))
+                        if (isInserter && buildPreview.ignoreCollider && (
+                            buildPreview.condition == EBuildCondition.TooFar ||
+                            buildPreview.condition == EBuildCondition.TooClose ||
+                            buildPreview.condition == EBuildCondition.OutOfReach))
                         {
                             buildPreview.condition = EBuildCondition.Ok;
                         } 
@@ -516,11 +518,6 @@ namespace DSP_Mods.CopyInserters
                 public CachedInserter ci;
                 public int otherId;
                 public Vector3 AssemblerPos;
-                public Vector3 pos;
-                public Vector3 pos2;
-                public Quaternion rot;
-                public Quaternion rot2;
-                public bool poseSet;
             }
 
 

--- a/DSP_CopyInserters/CopyInserters.cs
+++ b/DSP_CopyInserters/CopyInserters.cs
@@ -107,7 +107,8 @@ namespace DSP_Mods.CopyInserters
                     var bpCount = __instance.buildPreviews.Count;
                     for (int i = 0; i < bpCount; i++)
                     {
-                        var buildingPreview = __instance.buildPreviews[i];
+                        BuildPreview buildingPreview = __instance.buildPreviews[i];
+
                         if (!buildingPreview.item.prefabDesc.isInserter)
                         {
                             foreach (var inserter in ci)
@@ -442,6 +443,7 @@ namespace DSP_Mods.CopyInserters
                 var sourceEntity = ___factory.entityPool[sourceEntityId];
                 var sourcePos = sourceEntity.pos;
                 var sourceRot = sourceEntity.rot;
+
                 // Find connected inserters
                 var inserterPool = ___factory.factorySystem.inserterPool;
                 var entityPool = ___factory.entityPool;
@@ -597,6 +599,13 @@ namespace DSP_Mods.CopyInserters
                             targetPos = __instance.previewPose.position + __instance.previewPose.rotation * buildPreview.lpos;
                             targetRot = __instance.previewPose.rotation;
                         }
+
+                        // ignore buildings not being built at ground level
+                        if(__instance.multiLevelCovering)
+                        {
+                            continue;
+                        }
+
                         var entityPool = ___factory.entityPool;
                         foreach (var inserter in ci)
                         {

--- a/DSP_CopyInserters/CopyInserters.cs
+++ b/DSP_CopyInserters/CopyInserters.cs
@@ -18,7 +18,7 @@ namespace DSP_Mods.CopyInserters
         void Update()
         {
   
-            if (Input.GetKeyUp(KeyCode.Tab))
+            if (Input.GetKeyUp(KeyCode.Tab) && IsCopyAvailable())
             {
                 copyEnabled = !copyEnabled;
             }
@@ -583,7 +583,7 @@ namespace DSP_Mods.CopyInserters
                 var ci = PatchCopyInserters.cachedInserters;
                 if (CopyInserters.copyEnabled && ci.Count > 0)
                 {
-                    foreach (var buildPreview in __instance.buildPreviews)
+                    foreach (BuildPreview buildPreview in __instance.buildPreviews)
                     {
                         Vector3 targetPos;
                         Quaternion targetRot;

--- a/DSP_CopyInserters/CopyInserters.csproj
+++ b/DSP_CopyInserters/CopyInserters.csproj
@@ -111,6 +111,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy G:\DSPmods\DSP-Mods\DSP_CopyInserters\bin\Debug\CopyInserters.dll "G:\SteamLibrary\steamapps\common\Dyson Sphere Program\BepInEx\scripts"</PostBuildEvent>
+    <PostBuildEvent>copy $(TargetPath) "C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\BepInEx\scripts\$(TargetFileName)</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
There's probably some overlap with #10, but this takes all the deltas/etc and makes them relative to the source building rotation, which adds rotation support in the process. Feel free to cannibalize this or whatever you like.

Note that seems to partially fix some of the visual glitches as well, at least for my build, which I think were in part due to the special logic for reversing deltas when inserters were incoming. 