### PR TITLE
fix the rotation of the inserters when copying smelters

### DIFF
--- a/DSP_CopyInserters/PlayerAction_Build_Patch.cs
+++ b/DSP_CopyInserters/PlayerAction_Build_Patch.cs
@@ -326,6 +326,13 @@ namespace DSP_Mods.CopyInserters
             var sourcePos = sourceEntity.pos;
             var sourceRot = sourceEntity.rot;
 
+            if(sourceEntityProto.prefabDesc.assemblerRecipeType == ERecipeType.Smelt)
+            {
+                // Smelter rotation is not stored correctly. to ensure the inserters in the preview match the copied inserter
+                // we ignore the sourceRot and use the initial rotation of the previewed assembler
+                sourceRot = Maths.SphericalRotation(sourcePos, 0);
+            }
+
             // Find connected inserters
             var inserterPool = ___factory.factorySystem.inserterPool;
             var entityPool = ___factory.entityPool;


### PR DESCRIPTION
Smelters copying behaves weirdly (because the smelter model is rotationally invariant) and sometimes the preview created after copyin one is rotated by 90/28- or 270degrees (Depending on the original rotation of the smleter) and the inserters are pointing in the wrong direction

this pr fix this particular edge case by ensuring consistency between the previewPose and the copied Smelter rotation at copy time.