### PR TITLE
improve buildPreview positioning and highlight inserters that will not be built

### DIFF
--- a/DSP_CopyInserters/CopyInserters.cs
+++ b/DSP_CopyInserters/CopyInserters.cs
@@ -56,7 +56,11 @@ namespace DSP_Mods.CopyInserters
         internal void OnDestroy()
         {
             harmony.UnpatchSelf();  // For ScriptEngine hot-reloading
-            allTips.Remove(tip);
+            if(allTips!=null && tip != null)
+            {
+                allTips.Remove(tip);
+            }
+
         }
 
         public static bool IsCopyAvailable()


### PR DESCRIPTION
Thi PR address the last bit of ege cases weirdness in the collision detection logic by calculating the exact pose of the inserter at preview time. 
This means that the preview will be "exact" and not an approximation as it was before with no difference between the preview and the actual built inserter.

It also adds a visual style to inserter that will not be built as the result of having no connections. 
The inserter will appear:
 - white if it does not connect to a similar entity of the original
 - red if it connects but overlaps with another inserter/entity
 - blue if it connects and can be built correctly

