### PR TITLE
add memoization to GetPositions method

### DIFF
--- a/DSP_CopyInserters/CopyInserters.cs
+++ b/DSP_CopyInserters/CopyInserters.cs
@@ -52,6 +52,8 @@ namespace DSP_Mods.CopyInserters
             }
 
             PlayerAction_Build_Patch.cachedInserters = new List<PlayerAction_Build_Patch.CachedInserter>();
+            PlayerAction_Build_Patch.currentPositionCache = new Queue<PlayerAction_Build_Patch.InserterPosition>();
+            PlayerAction_Build_Patch.nextPositionCache = new Queue<PlayerAction_Build_Patch.InserterPosition>();
         }
         internal void OnDestroy()
         {


### PR DESCRIPTION
by additing memoization to GetPositions we can improve performance by over 50 times.

In this specific implementation the memoization strategy is to use a set of 2 'rotating' queues as we can rely on the fact that the inserters are always evaluated in the same order. 

If position/rotation of the evaluated building hasn't changed then by definition not even the one of the copied inserter has and we can reuse the result of the previous evaluation.